### PR TITLE
Fix crash when trying to mutate an immutable NSDictionary

### DIFF
--- a/Segment-Wootric/WTRWootricIntegration.m
+++ b/Segment-Wootric/WTRWootricIntegration.m
@@ -25,7 +25,7 @@
 - (void)identify:(SEGIdentifyPayload *)payload {
   NSString *email = payload.traits[@"email"];
   NSString *dateString = payload.traits[@"createdAt"];
-  NSMutableDictionary *endUserProperties = [payload.traits copy];
+  NSMutableDictionary *endUserProperties = [payload.traits mutableCopy];
   NSNumber *timestamp = [WTRWootricUtils timestampFromCreatedAt:dateString];
 
   [endUserProperties removeObjectsForKeys:@[@"email", @"createdAt"]];


### PR DESCRIPTION
The `WTRWootricIntegration` class tries to make a copy of the `traits` dictionary of `SEGIdentifyPayload`. The issue with this is that the copy is stored as a `NSMutableDictionary`, which is then mutated. However, the copy that is made is not mutable, so this throws an exception and crashes your app. The fix is to make a mutable copy of the `traits` dictionary. This is done by calling `mutableCopy` on the `traits` dictionary, as opposed to calling `copy`.
