### PR TITLE
Add EBS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.0 (2020-06-04)
+
+### Changes:
+
+- Update WootricSDK version
+- Add support for track()
+
 ## 0.2.0 (2018-05-24)
 
 ### Changes:

--- a/Segment-Wootric.podspec
+++ b/Segment-Wootric.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Segment-Wootric"
   s.module_name      = "SegmentWootric"
-  s.version          = "0.2.1"
+  s.version          = "0.3.0"
   s.summary          = "Wootric integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC
@@ -23,6 +23,6 @@ Pod::Spec.new do |s|
                           'Segment-Wootric/WTRWootricIntegration.h',
                           'Segment-Wootric/WTRWootricIntegrationFactory.h'
 
-  s.dependency 'Analytics', '~> 3.6.0'
-  s.dependency 'WootricSDK', '~> 0.9'
+  s.dependency 'Analytics', '~> 3.8.0'
+  s.dependency 'WootricSDK', '~> 0.18'
 end

--- a/Segment-Wootric.xcodeproj/project.pbxproj
+++ b/Segment-Wootric.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = B21372971BF0D150009F5974;
@@ -340,6 +341,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.Segment-Wootric";
 				PRODUCT_NAME = SegmentWootric;
 				SKIP_INSTALL = YES;
@@ -360,6 +362,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wootric.Segment-Wootric";
 				PRODUCT_NAME = SegmentWootric;
 				SKIP_INSTALL = YES;

--- a/Segment-Wootric/Support Files/Info.plist
+++ b/Segment-Wootric/Support Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.1</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Segment-Wootric/WTRWootricIntegration.m
+++ b/Segment-Wootric/WTRWootricIntegration.m
@@ -33,6 +33,18 @@
   [Wootric setEndUserProperties:endUserProperties];
 }
 
+- (void)track:(SEGTrackPayload *)payload {
+  NSDictionary *properties = payload.properties;
+  NSString *eventName = payload.event;
+  NSString *language = [properties objectForKey:@"language"];
+
+  if (language) {
+    [Wootric setCustomLanguage:language];
+  }
+
+  [Wootric setEventName:eventName];
+}
+
 + (SEGWootric *)wootric {
   return [[SEGWootric alloc] init];
 }


### PR DESCRIPTION
Add event-based sampling support.

## Test

- Checkout this branch
- Create Xcode project
- From directory do `pod init`
- Open `Podfile` and add
```ruby
pod 'Segment-Wootric', :path => 'YOUR-PATH/segment-wootric-ios'
```

This will install the library using the local branch.
- Setup Wootric using Segment. It should be something similar to this

```
  SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"WRITE_KEY"];
  WTRWootricIntegrationFactory *wootricFactory = [WTRWootricIntegrationFactory instance];
  [config use:wootricFactory];
  [SEGAnalytics setupWithConfiguration:config];
  
  [[SEGAnalytics sharedAnalytics] identify:@"userId123" traits:@{ @"email": @"example@segment.com" }];

  [[SEGAnalytics sharedAnalytics] track:@"Button click" properties:nil];
```

- Finally, to show the survey, you need to call `[WTRWootricIntegration showSurveyInViewController:self];` somewhere in your code.

**Note:** I'm assuming you have an account in Segment with Wootric configured. If you don't, DM me.